### PR TITLE
Support Request Headers

### DIFF
--- a/docs/data-sources/request.md
+++ b/docs/data-sources/request.md
@@ -23,6 +23,7 @@ Provision a Dex oauth2 client.
 ### Optional
 
 - `data` (String) The data sent in the request.
+- `headers` (String) Headers sent in the request.
 
 ### Read-Only
 

--- a/docs/data-sources/request.md
+++ b/docs/data-sources/request.md
@@ -23,7 +23,7 @@ Provision a Dex oauth2 client.
 ### Optional
 
 - `data` (String) The data sent in the request.
-- `headers` (Map) Headers sent in the request.
+- `headers` (Map of String) Key value headers to send with the request.
 
 ### Read-Only
 

--- a/docs/data-sources/request.md
+++ b/docs/data-sources/request.md
@@ -23,7 +23,7 @@ Provision a Dex oauth2 client.
 ### Optional
 
 - `data` (String) The data sent in the request.
-- `headers` (Map of String) Key value headers to send with the request.
+- `headers` (Map of String) Headers sent in the request.
 
 ### Read-Only
 

--- a/docs/data-sources/request.md
+++ b/docs/data-sources/request.md
@@ -23,7 +23,7 @@ Provision a Dex oauth2 client.
 ### Optional
 
 - `data` (String) The data sent in the request.
-- `headers` (String) Headers sent in the request.
+- `headers` (Map) Headers sent in the request.
 
 ### Read-Only
 

--- a/examples/with-headers/request.tf
+++ b/examples/with-headers/request.tf
@@ -1,7 +1,7 @@
 data "curl_request" "ipify" {
   uri         = "https://api.ipify.org?format=json"
   http_method = "GET"
-  headers = jsonencode({
+  headers = {
     Content-Type = "application/json"
-  })
+  }
 }

--- a/examples/with-headers/request.tf
+++ b/examples/with-headers/request.tf
@@ -1,0 +1,7 @@
+data "curl_request" "ipify" {
+  uri         = "https://api.ipify.org?format=json"
+  http_method = "GET"
+  headers = jsonencode({
+    Content-Type = "application/json"
+  })
+}

--- a/pkg/curl/data_request_test.go
+++ b/pkg/curl/data_request_test.go
@@ -68,9 +68,9 @@ func TestCurlRequestHeadersDataSource(t *testing.T) {
 data "curl_request" "ipify" {
 	uri         = "https://api.ipify.org?format=json"
 	http_method = "GET"
-	headers = jsonencode({
-		Content-Type = "application/json"
-	})
+	headers = {
+	  Content-Type = "application/json"
+	}
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -90,7 +90,7 @@ data "curl_request" "ipify" {
 						return nil
 					}),
 					resource.TestCheckResourceAttr(testIpifyResourceName, "response_status_code", "200"),
-					resource.TestCheckResourceAttr(testIpifyResourceName, "headers", "{\"Content-Type\":\"application/json\"}"),
+					resource.TestCheckResourceAttr(testIpifyResourceName, "headers.Content-Type", "application/json"),
 				),
 			},
 		},

--- a/pkg/curl/data_request_test.go
+++ b/pkg/curl/data_request_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	testResourceName = "data.curl_request.google"
+	testResourceName      = "data.curl_request.google"
+	testIpifyResourceName = "data.curl_request.ipify"
 )
 
 func TestCurlRequestDataSource(t *testing.T) {
@@ -51,6 +52,45 @@ data "curl_request" "google" {
 
 						return nil
 					}),
+				),
+			},
+		},
+	})
+}
+
+func TestCurlRequestHeadersDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: GetProviderConfig() + `
+data "curl_request" "ipify" {
+	uri         = "https://api.ipify.org?format=json"
+	http_method = "GET"
+	headers = jsonencode({
+		Content-Type = "application/json"
+	})
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(testIpifyResourceName, "uri", "https://api.ipify.org?format=json"),
+					resource.TestCheckResourceAttr(testIpifyResourceName, "http_method", "GET"),
+					resource.TestCheckResourceAttrWith(testIpifyResourceName, "id", func(value string) error {
+						id, err := strconv.ParseInt(value, 10, 64)
+						if err != nil {
+							return err
+						}
+
+						diff := time.Since(time.Unix(id, 0)).Seconds()
+						if diff > 1.5 {
+							return fmt.Errorf("expected ID to be within 1.5 seconds of current unix timestamp, was %f seconds difference", diff)
+						}
+
+						return nil
+					}),
+					resource.TestCheckResourceAttr(testIpifyResourceName, "response_status_code", "200"),
+					resource.TestCheckResourceAttr(testIpifyResourceName, "headers", "{\"Content-Type\":\"application/json\"}"),
 				),
 			},
 		},


### PR DESCRIPTION
Dear Maintainer,

Thanks for this provider. It kind of helps me to do certain tasks which can't be done with [restapi](https://github.com/Mastercard/terraform-provider-restapi) provider. 

With `headers` argument, one could pass `http` headers as mandated by few servers. It's an optional argument, hence shouldn't cause any problems to current ones. 

I appreciate your quick feedback on this as I am desperately waiting for this to be used in our internal corporate workflows. 

Looking forward to hearing from you soon. 